### PR TITLE
Missing quote marks for INTERFACE_LINK_LIBRARIES parameters

### DIFF
--- a/cps2cmake
+++ b/cps2cmake
@@ -180,7 +180,7 @@ def print_target_rules(package, component_name, component):
             cdeps = map(fixup, component.requires)
             ldeps = map(fixup, component.link_requires)
             deps = cdeps + map(lambda d: '$<LINK_ONLY:%s>' % d, ldeps)
-            print('  INTERFACE_LINK_LIBRARIES %s' % ';'.join(deps))
+            print('  INTERFACE_LINK_LIBRARIES "%s"' % ';'.join(deps))
 
         features = set()
         for feature in component.compile_features:


### PR DESCRIPTION
When multiple parameters are passed to INTERFACE_LINK_LIBRARIES, the list
of parameters must be between quote marks. If not, cmake will throw the
following error when encountering multiple libraries:

set_target_properties called with incorrect number of arguments.