### PR TITLE
Add supplemental schema to cps.py

### DIFF
--- a/cps.py
+++ b/cps.py
@@ -98,6 +98,8 @@ class Configuration(Object):
 
 #==============================================================================
 class Component(Configuration):
+    supplemental_schema = ['description', 'license']
+
     #--------------------------------------------------------------------------
     def __init__(self, json_data, prefix=None, package=None):
         super(Component, self).__init__(json_data, prefix, package)
@@ -105,6 +107,8 @@ class Component(Configuration):
         self.kind = _get('type', json_data, required=True)
         self.configurations = _make_dict(Configuration, 'configurations',
                                          json_data, prefix, package, self)
+        # Supplemental schema
+        _get_supplemental_schema(self, self.supplemental_schema, json_data)
 
 #==============================================================================
 class Requirement(Object):
@@ -140,6 +144,8 @@ class Platform(Object):
 
 #==============================================================================
 class Package(Object):
+    supplemental_schema = ['description', 'display-name', 'license', 'meta-comment', 'website']
+
     #--------------------------------------------------------------------------
     def __init__(self, path, json_data):
         super(Package, self).__init__(json_data)
@@ -168,6 +174,9 @@ class Package(Object):
 
         if self.compat_version is None:
             self.compat_version = self.version
+
+        # Supplemental schema
+        _get_supplemental_schema(self, self.supplemental_schema, json_data)
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -210,6 +219,14 @@ def _normalize_values(json_data, normalize_function):
 
     else:
         return json_data
+
+#------------------------------------------------------------------------------
+def _get_supplemental_schema(obj, schema, json_data):
+    for attribute in schema:
+        value = _get(attribute, json_data)
+        if value:
+            attribute_name = attribute.replace("-", "_")
+            setattr(obj, attribute_name, value)
 
 #------------------------------------------------------------------------------
 def _get(key, json_data, default=None, required=False):


### PR DESCRIPTION
Some attributes supported by CPS are part of the supplemental schema. These
attributes were not saved in the object created from the CPS file. This commit
add support for these attributes that are already documented as part of CPS.
If any or all of these attributes are not available in the CPS file, they
are simply ignored.