### PR TITLE
Add cps2pc, a script to convert cps files to pkgconfig files

### DIFF
--- a/cps2pc
+++ b/cps2pc
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+
+import argparse
+import cps
+from collections import OrderedDict
+import os
+import re
+import subprocess
+import sys
+
+_default_prefix = '${pcfiledir}/../..'
+
+_supported_compilers = ['gcc', 'clang']
+_supported_kernels = ['cygwin', 'linux', 'darwin']
+
+# Compile definitions
+_re_definitions = re.compile('(!)?(.*)')
+_unix_definition_prefixes = {None: '-D', '!': '-U'}
+_compilers_definition_prefixes = {
+    'gcc': _unix_definition_prefixes, 'clang': _unix_definition_prefixes}
+
+# Compile features
+_re_we_features = re.compile('((no)?(warn|error):(error$)?)(.*)')
+_W_we_prefixes = {
+    'warn:error': '-Werror', 'nowarn:error': '-Wno-error', 'warn:': '-W',
+    'nowarn:': '-Wno-', 'error:': '-Werror=', 'noerror:': '-Wno-error='}
+_compilers_we_prefixes = {'gcc': _W_we_prefixes, 'clang': _W_we_prefixes}
+_supported_compiler_feature_list = [
+    'c99', 'c11', 'c++03', 'c++11', 'c++14', 'c++17', 'gnu']
+_supported_gcc_features = {
+    x: '--std=%s' % x for x in _supported_compiler_feature_list}
+_supported_clang_features = _supported_gcc_features
+_supported_compile_features = {
+    'gcc': _supported_gcc_features, 'clang': _supported_clang_features}
+
+# Link features
+_supported_link_features = {x: {'threads': '-lpthread'}
+                            for x in _supported_kernels}
+
+#------------------------------------------------------------------------------
+def get_link_features(link_features, platform):
+
+    try:
+        features = []
+        for feature in link_features:
+            features.append(_supported_link_features[platform][feature])
+        return features
+    except KeyError as k:
+        sys.stderr.write("Unknown link feature %s on %s" % (k.message, platform))  # noqa
+
+#------------------------------------------------------------------------------
+def get_compile_features(compile_features, compiler):
+    features = []
+    # For loop with catch KeyError exception and check with
+    # WError, and W... flags
+    for feature in compile_features:
+        try:
+            features.append(_supported_compile_features[compiler][feature])
+        except KeyError as k:
+            ma = _re_we_features.match(feature)
+            if ma is not None:
+                features.append(
+                    _compilers_we_prefixes[compiler][ma.group(1)] + ma.group(5)
+                )
+                continue
+            sys.stderr.write(
+                "Unknown compile feature %s on %s" % (k.message, compiler))
+    return features
+
+#------------------------------------------------------------------------------
+def get_definitions_flags(compile_definitions, compiler):
+    definitions = []
+    for definition in compile_definitions:
+        try:
+            ma = _re_definitions.match(definition)
+            # No need to test result `ma` as regex catches everything.
+            prefix = _compilers_definition_prefixes[compiler][ma.groups()[0]]
+            definitions.append(prefix + ma.groups()[1])
+        except KeyError:
+            # This should never happen as the list of supported compilers
+            # is hard-coded and the definitions either start with `!` or don't.
+            # If we are here, there is a bug.
+            raise Exception("Problem reading definition argument `%s`. "
+                            "Most likely a bug in this script." % definition)
+    return definitions
+
+#------------------------------------------------------------------------------
+def get_platform(package):
+    try:
+        return package.platform.kernel
+    except AttributeError:
+        try:
+            output = subprocess.check_output(['uname', '-s'])
+            return output.strip().lower()
+        except OSError:
+            raise Exception("Unable to detect current platform")
+
+#------------------------------------------------------------------------------
+def get_kind_pc_dictionary(kind, location):
+    kind_dict = {}
+    if kind == 'exe':
+        raise Exception('executable')
+    elif kind in ["dylib", "static"] and location:
+        # Full path is specified directly without any flag.
+        kind_dict['Libs'] = [" %s" % location]
+    elif kind == "jar":
+        kind_dict['classpath'] = location
+    elif kind == "interface":
+        pass
+    else:
+        raise Exception(kind)
+    return kind_dict
+
+#------------------------------------------------------------------------------
+def write_pc(pc_dict, filename, prefix):
+    def list_to_str(l):
+        return " ".join(l)
+    convert = {'unicode': unicode, 'str': str, 'list': list_to_str}
+    with open(filename, "w") as f:
+        for k, v in pc_dict.iteritems():
+            f.write("%s: %s\n" % (k, convert[type(v).__name__](v).replace(
+                '@prefix@', prefix)))
+
+#------------------------------------------------------------------------------
+def remove_empty_keys(pc_dict):
+    for k, v in pc_dict.iteritems():
+        if not v:
+            pc_dict.pop(k)
+
+#------------------------------------------------------------------------------
+def write_targets_config(package, output_dir, compiler, prefix):
+    platform = get_platform(package)
+    for component_name, component in package.components.iteritems():
+        # Ignored CPS tags (not supported by pkgconfig):
+        # * Link-Languages
+        # * Configurations
+        pc_dict = OrderedDict()
+        pc_dict['Name'] = component_name
+        # Handle supplemental schema
+        for element in ['Description', 'Website']:
+            pc_dict[element] = package.data.get(element, None)
+
+        pc_dict['Version'] = package.version
+        pc_dict['Libs'] = []
+        try:
+            # In theory, we care about both `link_location` and `location`
+            # properties of the component. In practice, `link_location` either
+            # supersedes `location` or both variables have the same value.
+            pc_dict.update(
+                get_kind_pc_dictionary(component.kind, component.link_location)
+            )
+        except Exception as e:
+            print('Skipping %s: %s kind is not supported by pkgconfig' %\
+                  (component_name, e))
+            continue
+        pc_dict['Libs'] += component.link_libraries
+        if component.link_requires:
+            sys.stderr.write(
+                "Link-Requires found in input file but not supported.")
+        pc_dict['Libs'] += component.link_flags[None]
+        pc_dict['Libs'] += get_link_features(component.link_features, platform)
+        pc_dict['Cflags'] = []
+        pc_dict['Cflags'] += list(component.compile_flags[None])
+        pc_dict['Cflags'] += ["-I%s" % x for x in component.includes[None]]
+        pc_dict['Cflags'] += get_definitions_flags(
+            component.definitions[None], compiler)
+        pc_dict['Cflags'] += get_compile_features(
+            component.compile_features, compiler)
+        # Remove package name from possibly-qualified component names. This is
+        # a limited implementation that may not work in all cases and is likely
+        # to be improved in the future.
+        pc_dict['Requires'] = [x.split(':')[-1] for x in component.requires]
+        remove_empty_keys(pc_dict)
+        filename = os.path.join(output_dir, component_name + ".pc")
+        write_pc(pc_dict, filename, prefix)
+
+#------------------------------------------------------------------------------
+def main(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input', metavar='CPS_FILE', type=str,
+                        help='Input CPS file')
+    parser.add_argument('output', metavar='OUTPUT_DIRECTORY', type=str,
+                        help='Output directory for pkgconf files')
+    parser.add_argument('--compiler', choices=_supported_compilers,
+                        default=_supported_compilers[0],
+                        help='Targeted compiler')
+    parser.add_argument('--prefix', type=str,
+                        default=_default_prefix,
+                        help='Use given prefix instead of %s' % _default_prefix
+                        )
+
+    args = parser.parse_args(args)
+    package = cps.read(args.input, canonicalize=True)
+
+    write_targets_config(package, args.output, args.compiler, args.prefix)
+
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
The new scripts takes 2 required parameters:
* The input CPS file
* And output directory
Additionally, 2 optional paramters can be given:
* The compiler that the pkgconfig options are created for (default is `gcc`).
* A prefix to replace the value '@prefix@' given in the CPS file (default is
`${pcfiledir}/../..`).

A pkgconfig file will be created for each individual component listed in the
CPS file.
The pkgconfig file is generated for a specific compilter. If not specified,
`gcc` will be used by default. This is necessary because a certain number of
parameters contained in the CPS file need to be converted from their generic
declaration to actual flags given to the compiler. This includes definitions,
link, runtime, and compile features.

The current implementation is limited: It only support a limited number of
compilers (gcc, clang), runtimes, kernels, and compiler features. The
implementation design mostly using dictionaries should allow to extend the
implementation easily if necessary, by simply adding new keys
to the dictionaries.

Certain CPS tags are ignored as they are not supported by pkgconfig:
* Link-Location
* Link-Languages
* Configurations